### PR TITLE
Fixed Logic Error

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -31,7 +31,7 @@
             // fileName_TextBox
             // 
             this.fileName_TextBox.BackColor = System.Drawing.SystemColors.Control;
-            this.fileName_TextBox.Enabled = false;
+            this.fileName_TextBox.ForeColor = System.Drawing.SystemColors.WindowText;
             this.fileName_TextBox.Location = new System.Drawing.Point(12, 21);
             this.fileName_TextBox.Name = "fileName_TextBox";
             this.fileName_TextBox.ReadOnly = true;
@@ -62,12 +62,11 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(184, 211);
+            this.ClientSize = new System.Drawing.Size(184, 121);
             this.Controls.Add(this.format_Button);
             this.Controls.Add(this.selectFile_button);
             this.Controls.Add(this.fileName_TextBox);
             this.Name = "Form1";
-            this.Text = "Form1";
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -14,6 +14,7 @@ namespace FormatNames {
             fileName_TextBox.BackColor = System.Drawing.SystemColors.Control;
             if (openfiledialog1.ShowDialog() == DialogResult.OK) {
                 path = openfiledialog1.FileName;
+                fileName_TextBox.ForeColor = Color.Black;
                 fileName_TextBox.Text = openfiledialog1.SafeFileName;
             }
         }
@@ -39,23 +40,29 @@ namespace FormatNames {
                     }
                 }
                 fileName_TextBox.BackColor = Color.LimeGreen;
+
+                for (int i = 1; i < incorrectFormat.Count; i += 2) {
+                    correctFormat.Add(incorrectFormat[i] + " " + incorrectFormat[i - 1]);
+                }
+
+                File.WriteAllLines(path, correctFormat);
+                using (StreamWriter sw = File.CreateText(path)) {
+                    foreach (string s in correctFormat) {
+                        sw.WriteLine(s);
+                    }
+                }
             }
             else {
                 Console.Error.WriteLine("File Path Error");
                 fileName_TextBox.BackColor = Color.Firebrick;
-            }
-
-            for (int i = 1; i< incorrectFormat.Count; i+= 2) {
-                correctFormat.Add(incorrectFormat[i] + " " + incorrectFormat[i - 1]);
-            }
-
-            File.WriteAllLines(path, correctFormat);
-            using (StreamWriter sw = File.CreateText(path)) {
-                foreach(string s in correctFormat) {
-                    sw.WriteLine(s);
+                fileName_TextBox.ForeColor = Color.White;
+                if (path == "") {
+                    fileName_TextBox.Text = "Error: Select a file first";
+                }
+                else {
+                    fileName_TextBox.Text = "Error: Bad file path";
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
Tested program and discovered an issue. If you clicked on the format button before selecting a file the program crashed. This is due to a logic error in the code executing changes to the file outside of the safeguards. Moved logic into the File.Exists block where it belongs and added error message in the UI prompting the user to select a file first.

Also took a look at the UI, super simple program so there isn't much to improve on. UI is as simple and intuitive as it gets.

Got rid of extra whitespace in the window.

Color the text window red if program fails (error code posts) and green if it works. Can't get much easier to understand than that.